### PR TITLE
Add spread syntax for incoming argument

### DIFF
--- a/JavaScript/5-chain.js
+++ b/JavaScript/5-chain.js
@@ -23,7 +23,7 @@ const chain = (prev = null) => {
   };
   cur.forward = () => {
     console.log('Forward');
-    if (cur.fn) cur.fn(cur.args, (err, data) => {
+    if (cur.fn) cur.fn(...cur.args, (err, data) => {
       console.log('Callback from ' + cur.fn.name);
       console.dir({ data });
       if (!err && cur.next) cur.next.forward();


### PR DESCRIPTION
Tiny fix: args should come into function not in array format.
Timur, thank you for great material! 